### PR TITLE
fix: unable to configure integration on  HA 2026.4+

### DIFF
--- a/custom_components/eau_grand_lyon/config_flow.py
+++ b/custom_components/eau_grand_lyon/config_flow.py
@@ -30,6 +30,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
 
 def validate_email(email: str) -> str:
     """Valide le format de l'email."""
@@ -47,8 +49,8 @@ def validate_password(password: str) -> str:
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_EMAIL): vol.All(str, vol.Length(min=1), validate_email),
-        vol.Required(CONF_PASSWORD): vol.All(str, vol.Length(min=1), validate_password),
+        vol.Required(CONF_EMAIL): str,  # no validator here
+        vol.Required(CONF_PASSWORD): vol.All(str, vol.Length(min=4)),  # Length is fine
         vol.Optional(CONF_TARIF_M3, default=DEFAULT_TARIF_M3): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=30.0)),
     }
 )
@@ -84,36 +86,39 @@ class EauGrandLyonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             password = user_input[CONF_PASSWORD]
 
             jar = aiohttp.CookieJar(unsafe=True)
-            async with aiohttp.ClientSession(cookie_jar=jar) as session:
-                api = EauGrandLyonApi(session, email, password)
-                try:
-                    await api.authenticate()
-                except AuthenticationError as err:
-                    _LOGGER.warning("Auth échouée: %s", err)
-                    errors["base"] = "invalid_auth"
-                except WafBlockedError as err:
-                    _LOGGER.warning("Blocage WAF: %s", err)
-                    errors["base"] = "waf_blocked"
-                except NetworkError as err:
-                    _LOGGER.warning("Erreur réseau: %s", err)
-                    errors["base"] = "cannot_connect"
-                except ApiError as err:
-                    _LOGGER.warning("Erreur API: %s", err)
-                    errors["base"] = "api_error"
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.exception("Erreur inattendue: %s", err)
-                    errors["base"] = "unknown"
-                else:
-                    await self.async_set_unique_id(email.lower())
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(
-                        title=f"Eau du Grand Lyon ({email})",
-                        data={
-                            CONF_EMAIL: email,
-                            CONF_PASSWORD: password,
-                            CONF_TARIF_M3: user_input[CONF_TARIF_M3],
-                        },
-                    )
+            if not _EMAIL_REGEX.match(email):
+                errors[CONF_EMAIL] = "invalid_email"
+            else:
+                async with aiohttp.ClientSession(cookie_jar=jar) as session:
+                    api = EauGrandLyonApi(session, email, password)
+                    try:
+                        await api.authenticate()
+                    except AuthenticationError as err:
+                        _LOGGER.warning("Auth échouée: %s", err)
+                        errors["base"] = "invalid_auth"
+                    except WafBlockedError as err:
+                        _LOGGER.warning("Blocage WAF: %s", err)
+                        errors["base"] = "waf_blocked"
+                    except NetworkError as err:
+                        _LOGGER.warning("Erreur réseau: %s", err)
+                        errors["base"] = "cannot_connect"
+                    except ApiError as err:
+                        _LOGGER.warning("Erreur API: %s", err)
+                        errors["base"] = "api_error"
+                    except Exception as err:  # noqa: BLE001
+                        _LOGGER.exception("Erreur inattendue: %s", err)
+                        errors["base"] = "unknown"
+                    else:
+                        await self.async_set_unique_id(email.lower())
+                        self._abort_if_unique_id_configured()
+                        return self.async_create_entry(
+                            title=f"Eau du Grand Lyon ({email})",
+                            data={
+                                CONF_EMAIL: email,
+                                CONF_PASSWORD: password,
+                                CONF_TARIF_M3: user_input[CONF_TARIF_M3],
+                            },
+                        )
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
The root cause is that HA 2026.4 can no longer serialize custom validator functions in Voluptuous schemas when converting them to JSON for the frontend. Both validate_email and vol.Email() fail with:
```

ValueError: Unable to convert schema: <function validate_email at 0x...>
ValueError: Unable to convert schema: <function Email at 0x...>
```

fix #2 
