### PR TITLE
fix: 5 bugs remontés utilisateurs (labels mois, précision index, fuit…

### DIFF
--- a/custom_components/eau_grand_lyon/api/client.py
+++ b/custom_components/eau_grand_lyon/api/client.py
@@ -626,9 +626,12 @@ class EauGrandLyonApi:
         for entry in raw_entries:
             try:
                 month_raw = int(entry["mois"])
-                if not 1 <= month_raw <= 12:
+                # L'API Téléo envoie les mois en base-0 (0=Janvier … 11=Décembre).
+                # Ancienne validation 1-12 sautait Janvier (mois=0) et décalait tous
+                # les autres d'un rang (Décembre mois=11 → MONTHS_FR[10]="Novembre").
+                if not 0 <= month_raw <= 11:
                     continue
-                month_idx = month_raw - 1
+                month_idx = month_raw  # déjà base-0, pas de soustraction
                 year = int(entry["annee"])
                 result.append(
                     {

--- a/custom_components/eau_grand_lyon/binary_sensor.py
+++ b/custom_components/eau_grand_lyon/binary_sensor.py
@@ -140,10 +140,16 @@ class EauGrandLyonRealTimeLeakSensor(_EauGrandLyonBinaryBase):
 
 
 class EauGrandLyonLocalLeakSensor(_EauGrandLyonBinaryBase):
-    """Alerte fuite basée sur une analyse de pattern locale (conso constante)."""
+    """Alerte fuite basée sur une analyse de pattern locale (spike statistique).
+
+    Désactivé par défaut : l'algorithme nécessite au moins 7 jours d'historique
+    journalier et peut produire des faux positifs sur les compteurs sans courbe
+    intra-journalière (un seul relevé par 24h).
+    """
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_translation_key = "local_leak"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator, entry, contract_ref):
         super().__init__(coordinator, entry, contract_ref)

--- a/custom_components/eau_grand_lyon/config_flow.py
+++ b/custom_components/eau_grand_lyon/config_flow.py
@@ -267,7 +267,7 @@ class EauGrandLyonOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_UPDATE_INTERVAL_HOURS,
                     default=current_interval,
-                ): vol.In(_INTERVAL_OPTIONS),
+                ): vol.All(vol.Coerce(int), vol.In(_INTERVAL_OPTIONS)),
                 vol.Optional(
                     CONF_TARIF_M3,
                     default=current_tarif,

--- a/custom_components/eau_grand_lyon/coordinator.py
+++ b/custom_components/eau_grand_lyon/coordinator.py
@@ -201,7 +201,8 @@ class EauGrandLyonCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         # Historique mensuel cumulatif — accumule jusqu'à 36 mois pour le calcul N-1
         # (l'API ne retourne que 12 mois ; ce store persiste les mois précédents entre mises à jour)
-        self._monthly_history_store = Store(hass, 1, f"{DOMAIN}_{entry.entry_id}_monthly_history")
+        # Version 2 : correction du bug mois base-0 (v1 avait des mois_index décalés d'un rang).
+        self._monthly_history_store = Store(hass, 2, f"{DOMAIN}_{entry.entry_id}_monthly_history")
         self._monthly_history: dict[str, list[dict]] = {}
 
         if experimental:
@@ -878,15 +879,30 @@ class EauGrandLyonCoordinator(DataUpdateCoordinator[CoordinatorData]):
         return round(sum(valeurs), 3) if valeurs else None
 
     def _detect_local_leak(self, courbe: list[dict], daily: list[dict], ref: str) -> bool:
-        """Détecte une fuite locale par analyse de pattern."""
+        """Détecte une fuite locale par analyse de pattern.
+
+        L'API Téléo ne pousse qu'un index par 24h, donc la règle "jamais à 0 sur
+        24h" est toujours vraie dans un logement habité. On utilise à la place un
+        seuil statistique : alerte si la conso du dernier jour dépasse 2,5× la
+        moyenne glissante des 7 derniers jours (minimum 50 L/j pour éviter les
+        faux positifs sur de très faibles consos).
+        """
         if courbe:
             vals = [e.get("valeur", 0) for e in courbe if "valeur" in e]
+            # Courbe intra-journalière : flux non-nul en permanence sur 24h+ = fuite probable.
             if len(vals) >= 24 and all(v > 0 for v in vals):
                 _LOGGER.warning("Suspected leak (flat 24h+ pattern): %s", ref)
                 return True
-        elif daily:
-            recent_7 = [e["consommation_m3"] for e in daily[-7:]]
-            if len(recent_7) >= 7 and all(v > 0.05 for v in recent_7):
+        elif daily and len(daily) >= 7:
+            recent = [e["consommation_m3"] for e in daily[-7:]]
+            moyenne_7j = sum(recent) / len(recent)
+            last = recent[-1]
+            seuil = max(moyenne_7j * 2.5, 0.5)   # au moins 500 L/j pour déclencher
+            if moyenne_7j > 0 and last > seuil:
+                _LOGGER.warning(
+                    "Suspected leak (daily spike): %s — last=%.3f m³, avg7j=%.3f m³",
+                    ref, last, moyenne_7j,
+                )
                 return True
         return False
 
@@ -1118,14 +1134,14 @@ class EauGrandLyonCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Priority 1: real index from experimental SIAMM endpoint
         real = contract.get("real_index")
         if real is not None:
-            result = round(real, 1)
+            result = round(real, 3)
         # Priority 2: last known meter index from daily Téléo data (no experimental needed)
         elif contract.get("index_journalier_dernier") is not None:
-            result = round(contract["index_journalier_dernier"], 1)
+            result = round(contract["index_journalier_dernier"], 3)
         # Priority 3: sum of monthly consumptions (relative, but works for Energy dashboard)
         else:
             consos = contract.get("consommations", [])
-            result = round(sum(e["consommation_m3"] for e in consos), 1) if consos else None
+            result = round(sum(e["consommation_m3"] for e in consos), 3) if consos else None
         self._cumulative_index_cache[contract_ref] = result
         return result
 

--- a/custom_components/eau_grand_lyon/sensors/consumption.py
+++ b/custom_components/eau_grand_lyon/sensors/consumption.py
@@ -87,7 +87,7 @@ class EauGrandLyonConsommationSensor(_EauGrandLyonBase):
     """Consommation du mois courant ou précédent (m³)."""
 
     _attr_device_class = SensorDeviceClass.WATER
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = "m³"
     _attr_suggested_display_precision = 1
 


### PR DESCRIPTION
…e, fréquence, state_class)

- api/client.py: corrige le décalage mensuel — l'API Téléo envoie les mois en base-0 (0=Janvier…11=Décembre) ; l'ancien code appliquait `month_raw - 1` sur une valeur déjà base-0, sautant Janvier et décalant tous les labels d'un rang (Mai affiché comme Avril, Décembre marqué manquant).

- coordinator.py: bump Store version 1→2 pour invalider le cache corrompu (mois_index incorrects) au prochain démarrage, sans intervention manuelle.

- coordinator.py (get_cumulative_index): `round(x, 1)` → `round(x, 3)` sur les 3 branches — l'index 326.014 m³ n'est plus tronqué à 326.0.

- coordinator.py (_detect_local_leak): remplace la règle « conso jamais à 0 sur 7j » (toujours vraie dans un logement habité avec 1 relevé/24h) par un seuil statistique : alerte si conso_j > max(moyenne_7j × 2,5 ; 500 L/j).

- binary_sensor.py (EauGrandLyonLocalLeakSensor): désactivé par défaut (`entity_registry_enabled_default = False`) — l'utilisateur l'active manuellement une fois son historique 7j établi.

- config_flow.py: `vol.In(_INTERVAL_OPTIONS)` → `vol.All(vol.Coerce(int), vol.In(...))` — le formulaire HA soumet la valeur en string ("24"), ce qui levait "Value must be one of [6, 12, 24, 48]" à chaque changement de fréquence.

- sensors/consumption.py: `state_class: TOTAL` → `TOTAL_INCREASING` pour que le dashboard Énergie natif de HA puisse dériver les deltas horaires/journaliers.